### PR TITLE
remove mariadb references, add WORKDIR and label hooks to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM lsiobase/xenial
 MAINTAINER phendryx
 
+# set version label
+ARG BUILD_DATE
+ARG VERSION
+LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
+
 # environment settings
 ARG DEBIAN_FRONTEND="noninteractive"
 
@@ -17,6 +22,7 @@ ARG BUILD_PACKAGES="\
     ruby-full \
     zlib1g-dev"
 
+# copy app
 COPY app/ /opt/docker-readme-sync/
 
 # install runtime packages
@@ -62,5 +68,6 @@ RUN \
 COPY root/ /
 
 # ports and volumes
+WORKDIR /opt/docker-readme-sync
 EXPOSE 80 443
 VOLUME /config

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 [linuxserverurl]: https://linuxserver.io
 [forumurl]: https://forum.linuxserver.io
 [ircurl]: https://www.linuxserver.io/irc/
@@ -22,7 +21,7 @@ Utility to copy README.md from a given github.com repository to a given dockerhu
 
 ```
 docker create \
---name=docker-readme-sync \
+--name=readme-sync \
 -e PUID=<UID> \
 -e PGID=<GID> \
 -p 80:80 \
@@ -37,7 +36,7 @@ lsiodev/readme-sync
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 
-It is based on ubuntu xenial with s6 overlay, for shell access whilst the container is running do `docker exec -it docker-readme-sync /bin/bash`.
+It is based on ubuntu xenial with s6 overlay, for shell access whilst the container is running do `docker exec -it readme-sync /bin/bash`.
 
 ### User / Group Identifiers
 
@@ -65,22 +64,22 @@ In the examples below, `github_repo` and `dockerhub_repo` should look similar `l
 
 ### Command Line
 
-`docker exec -it docker-readme-sync bash -c "cd /opt/github-dockerhub-sync/ && rake update[<github_repo>,<dockerhub_repo>]"`
+`docker exec -it readme-sync bash -c "rake update[<github_repo>,<dockerhub_repo>]"`
 
 ## Info
 
-* Shell access whilst the container is running: `docker exec -it mariadb /bin/bash`
-* To monitor the logs of the container in realtime: `docker logs -f mariadb`
+* Shell access whilst the container is running: `docker exec -it readme-sync /bin/bash`
+* To monitor the logs of the container in realtime: `docker logs -f readme-sync`
 
 * container version number 
 
-`docker inspect -f '{{ index .Config.Labels "build_version" }}' mariadb`
+`docker inspect -f '{{ index .Config.Labels "build_version" }}' readme-sync`
 
 * image version number
 
-`docker inspect -f '{{ index .Config.Labels "build_version" }}' linuxserver/mariadb`
+`docker inspect -f '{{ index .Config.Labels "build_version" }}' linuxserver/readme-sync`
 
 ## Versions
+
 + **16.10.16:** merge ruby app.
 + **11.10.16:** Initial development release.
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->
## Thanks, team linuxserver.io
- added WORKDIR directive to Dockerfile, eliminates need to cd to folder in exec line
- added label hooks to Dockerfile, when image goes final will get version information etc.
- shortened name from docker-readme-sync to readme-sync in README create line and info etc.
- killed last remaining refs to mariadb in README
