### PR TITLE
add external folder support

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,13 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord chat support
+    url: https://discord.gg/YWrKVTn
+    about: Realtime support / chat with the community and the team.
+
+  - name: Discourse discussion forum
+    url: https://discourse.linuxserver.io
+    about: Post on our community forum.
+
+  - name: Documentation
+    url: https://docs.linuxserver.io
+    about: Documentation - information about all of our containers.

--- a/.github/ISSUE_TEMPLATE/issue.bug.md
+++ b/.github/ISSUE_TEMPLATE/issue.bug.md
@@ -1,0 +1,40 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+[linuxserverurl]: https://linuxserver.io
+[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
+
+<!--- If you are new to Docker or this application our issue tracker is **ONLY** used for reporting bugs or requesting features. Please use [our discord server](https://discord.gg/YWrKVTn) for general support. --->
+
+<!--- Provide a general summary of the bug in the Title above -->
+
+------------------------------
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Steps to Reproduce
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Environment
+**OS:**
+**CPU architecture:** x86_64/arm32/arm64
+**How docker service was installed:**
+<!--- ie. from the official docker repo, from the distro repo, nas OS provided, etc. -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Command used to create docker container (run/create/compose/screenshot)
+<!--- Provide your docker create/run command or compose yaml snippet, or a screenshot of settings if using a gui to create the container -->
+
+## Docker logs
+<!--- Provide a full docker log, output of "docker logs readme-sync" -->

--- a/.github/ISSUE_TEMPLATE/issue.feature.md
+++ b/.github/ISSUE_TEMPLATE/issue.feature.md
@@ -1,0 +1,25 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+[linuxserverurl]: https://linuxserver.io
+[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
+
+<!--- If you are new to Docker or this application our issue tracker is **ONLY** used for reporting bugs or requesting features. Please use [our discord server](https://discord.gg/YWrKVTn) for general support. --->
+
+<!--- If this acts as a feature request please ask yourself if this modification is something the whole userbase will benefit from --->
+<!--- If this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
+
+<!--- Provide a general summary of the request in the Title above -->
+
+------------------------------
+
+## Desired Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+## Alternatives Considered
+<!--- Tell us what other options you have tried or considered -->

--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -1,0 +1,16 @@
+name: External Trigger Main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  external-trigger-master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+
+      - name: External Trigger
+        if: github.ref == 'refs/heads/master'
+        run: |
+          echo "**** No external release, exiting ****"
+          exit 0

--- a/.github/workflows/external_trigger_scheduler.yml
+++ b/.github/workflows/external_trigger_scheduler.yml
@@ -1,0 +1,43 @@
+name: External Trigger Scheduler
+
+on:
+  schedule:
+    - cron:  '25 * * * *'
+  workflow_dispatch:
+
+jobs:
+  external-trigger-scheduler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: '0'
+
+      - name: External Trigger Scheduler
+        run: |
+          echo "**** Branches found: ****"
+          git for-each-ref --format='%(refname:short)' refs/remotes
+          echo "**** Pulling the yq docker image ****"
+          docker pull ghcr.io/linuxserver/yq
+          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
+          do
+            br=$(echo "$br" | sed 's|origin/||g')
+            echo "**** Evaluating branch ${br} ****"
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-readme-sync/${br}/jenkins-vars.yml \
+              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            if [ "$br" == "$ls_branch" ]; then
+              echo "**** Branch ${br} appears to be live; checking workflow. ****"
+              if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-readme-sync/${br}/.github/workflows/external_trigger.yml > /dev/null 2>&1; then
+                echo "**** Workflow exists. Triggering external trigger workflow for branch ${br} ****."
+                curl -iX POST \
+                  -H "Authorization: token ${{ secrets.CR_PAT }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -d "{\"ref\":\"refs/heads/${br}\"}" \
+                  https://api.github.com/repos/linuxserver/docker-readme-sync/actions/workflows/external_trigger.yml/dispatches
+              else
+                echo "**** Workflow doesn't exist; skipping trigger. ****"
+              fi
+            else
+              echo "**** ${br} appears to be a dev branch; skipping trigger. ****"
+            fi
+          done

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -8,6 +8,6 @@ jobs:
     steps:
     - uses: actions/first-interaction@v1
       with:
-        issue-message: 'Thanks for opening your first issue here! Be sure to follow the [issue template](https://github.com/linuxserver/docker-readme-sync/blob/master/.github/ISSUE_TEMPLATE.md)!'
+        issue-message: 'Thanks for opening your first issue here! Be sure to follow the [bug](https://github.com/linuxserver/docker-readme-sync/blob/master/.github/ISSUE_TEMPLATE/issue.bug.md) or [feature](https://github.com/linuxserver/docker-readme-sync/blob/master/.github/ISSUE_TEMPLATE/issue.feature.md) issue templates!'
         pr-message: 'Thanks for opening this pull request! Be sure to follow the [pull request template](https://github.com/linuxserver/docker-readme-sync/blob/master/.github/PULL_REQUEST_TEMPLATE.md)!'
         repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package_trigger.yml
+++ b/.github/workflows/package_trigger.yml
@@ -1,0 +1,38 @@
+name: Package Trigger Main
+
+on:
+  workflow_dispatch:
+
+jobs:
+  package-trigger-master:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+
+      - name: Package Trigger
+        if: github.ref == 'refs/heads/master'
+        run: |
+          if [ -n "${{ secrets.PAUSE_PACKAGE_TRIGGER_README_SYNC_MASTER }}" ]; then
+            echo "**** Github secret PAUSE_PACKAGE_TRIGGER_README_SYNC_MASTER is set; skipping trigger. ****"
+            exit 0
+          fi
+          if [ $(curl -s https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-readme-sync/job/master/lastBuild/api/json | jq -r '.building') == "true" ]; then
+            echo "**** There already seems to be an active build on Jenkins; skipping package trigger ****"
+            exit 0
+          fi
+          echo "**** Package trigger running off of master branch. To disable, set a Github secret named \"PAUSE_PACKAGE_TRIGGER_README_SYNC_MASTER\". ****"
+          response=$(curl -iX POST \
+            https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-readme-sync/job/master/buildWithParameters?PACKAGE_CHECK=true \
+            --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} | grep -i location | sed "s|^[L|l]ocation: \(.*\)|\1|")
+          echo "**** Jenkins job queue url: ${response%$'\r'} ****"
+          echo "**** Sleeping 10 seconds until job starts ****"
+          sleep 10
+          buildurl=$(curl -s "${response%$'\r'}api/json" | jq -r '.executable.url')
+          buildurl="${buildurl%$'\r'}"
+          echo "**** Jenkins job build url: ${buildurl} ****"
+          echo "**** Attempting to change the Jenkins job description ****"
+          curl -iX POST \
+            "${buildurl}submitDescription" \
+            --user ${{ secrets.JENKINS_USER }}:${{ secrets.JENKINS_TOKEN }} \
+            --data-urlencode "description=GHA package trigger https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --data-urlencode "Submit=Submit"

--- a/.github/workflows/package_trigger_scheduler.yml
+++ b/.github/workflows/package_trigger_scheduler.yml
@@ -1,0 +1,50 @@
+name: Package Trigger Scheduler
+
+on:
+  schedule:
+    - cron:  '05 12 * * 0'
+  workflow_dispatch:
+
+jobs:
+  package-trigger-scheduler:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.3
+        with:
+          fetch-depth: '0'
+
+      - name: Package Trigger Scheduler
+        run: |
+          echo "**** Branches found: ****"
+          git for-each-ref --format='%(refname:short)' refs/remotes
+          echo "**** Pulling the yq docker image ****"
+          docker pull ghcr.io/linuxserver/yq
+          for br in $(git for-each-ref --format='%(refname:short)' refs/remotes)
+          do
+            br=$(echo "$br" | sed 's|origin/||g')
+            echo "**** Evaluating branch ${br} ****"
+            ls_branch=$(curl -sX GET https://raw.githubusercontent.com/linuxserver/docker-readme-sync/${br}/jenkins-vars.yml \
+              | docker run --rm -i --entrypoint yq ghcr.io/linuxserver/yq -r .ls_branch)
+            if [ "${br}" == "${ls_branch}" ]; then
+              echo "**** Branch ${br} appears to be live; checking workflow. ****"
+              if curl -sfX GET https://raw.githubusercontent.com/linuxserver/docker-readme-sync/${br}/.github/workflows/package_trigger.yml > /dev/null 2>&1; then
+                echo "**** Workflow exists. Triggering package trigger workflow for branch ${br}. ****"
+                triggered_branches="${triggered_branches}${br} "
+                curl -iX POST \
+                  -H "Authorization: token ${{ secrets.CR_PAT }}" \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  -d "{\"ref\":\"refs/heads/${br}\"}" \
+                  https://api.github.com/repos/linuxserver/docker-readme-sync/actions/workflows/package_trigger.yml/dispatches
+                sleep 30
+              else
+                echo "**** Workflow doesn't exist; skipping trigger. ****"
+              fi
+            else
+              echo "**** ${br} appears to be a dev branch; skipping trigger. ****"
+            fi
+          done
+          echo "**** Package check build(s) triggered for branch(es): ${triggered_branches} ****"
+          echo "**** Notifying Discord ****"
+          curl -X POST -H "Content-Type: application/json" --data '{"avatar_url": "https://cdn.discordapp.com/avatars/354986384542662657/df91181b3f1cf0ef1592fbe18e0962d7.png","embeds": [{"color": 9802903,
+            "description": "**Package Check Build(s) Triggered for readme-sync** \n**Branch(es):** '"${triggered_branches}"' \n**Build URL:** '"https://ci.linuxserver.io/blue/organizations/jenkins/Docker-Pipeline-Builders%2Fdocker-readme-sync/activity/"' \n"}],
+            "username": "Github Actions"}' ${{ secrets.DISCORD_WEBHOOK }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:3.12
+FROM ghcr.io/linuxserver/baseimage-alpine:3.12
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm64v8-3.12
+FROM ghcr.io/linuxserver/baseimage-alpine:arm64v8-3.12
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM lsiobase/alpine:arm32v7-3.12
+FROM ghcr.io/linuxserver/baseimage-alpine:arm32v7-3.12
 
 # set version label
 ARG BUILD_DATE

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
         script{
           env.EXIT_STATUS = ''
           env.LS_RELEASE = sh(
-            script: '''docker run --rm alexeiled/skopeo sh -c 'skopeo inspect docker://docker.io/'${DOCKERHUB_IMAGE}':latest 2>/dev/null' | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
+            script: '''docker run --rm ghcr.io/linuxserver/alexeiled-skopeo sh -c 'skopeo inspect docker://docker.io/'${DOCKERHUB_IMAGE}':latest 2>/dev/null' | jq -r '.Labels.build_version' | awk '{print $3}' | grep '\\-ls' || : ''',
             returnStdout: true).trim()
           env.LS_RELEASE_NOTES = sh(
             script: '''cat readme-vars.yml | awk -F \\" '/date: "[0-9][0-9].[0-9][0-9].[0-9][0-9]:/ {print $4;exit;}' | sed -E ':a;N;$!ba;s/\\r{0,1}\\n/\\\\n/g' ''',
@@ -49,7 +49,7 @@ pipeline {
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/commit/' + env.GIT_COMMIT
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DOCKERHUB_IMAGE + '/tags/'
           env.PULL_REQUEST = env.CHANGE_ID
-          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml'
+          env.TEMPLATED_FILES = 'Jenkinsfile README.md LICENSE ./.github/CONTRIBUTING.md ./.github/FUNDING.yml ./.github/ISSUE_TEMPLATE/config.yml ./.github/ISSUE_TEMPLATE/issue.bug.md ./.github/ISSUE_TEMPLATE/issue.feature.md ./.github/PULL_REQUEST_TEMPLATE.md ./.github/workflows/greetings.yml ./.github/workflows/stale.yml ./.github/workflows/package_trigger.yml ./.github/workflows/package_trigger_scheduler.yml ./.github/workflows/external_trigger.yml ./.github/workflows/external_trigger_scheduler.yml'
         }
         script{
           env.LS_RELEASE_NUMBER = sh(
@@ -120,13 +120,14 @@ pipeline {
       steps {
         script{
           env.IMAGE = env.DOCKERHUB_IMAGE
-          env.GITHUBIMAGE = 'docker.pkg.github.com/' + env.LS_USER + '/' + env.LS_REPO + '/' + env.CONTAINER_NAME
+          env.GITHUBIMAGE = 'ghcr.io/' + env.LS_USER + '/' + env.CONTAINER_NAME
           env.GITLABIMAGE = 'registry.gitlab.com/linuxserver.io/' + env.LS_REPO + '/' + env.CONTAINER_NAME
           if (env.MULTIARCH == 'true') {
             env.CI_TAGS = 'amd64-' + env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER + '|arm32v7-' + env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER + '|arm64v8-' + env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER
           } else {
             env.CI_TAGS = env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER
           }
+          env.VERSION_TAG = env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER
           env.META_TAG = env.EXT_RELEASE_CLEAN + '-ls' + env.LS_TAG_NUMBER
           env.EXT_RELEASE_TAG = 'version-' + env.EXT_RELEASE_CLEAN
         }
@@ -141,13 +142,14 @@ pipeline {
       steps {
         script{
           env.IMAGE = env.DEV_DOCKERHUB_IMAGE
-          env.GITHUBIMAGE = 'docker.pkg.github.com/' + env.LS_USER + '/' + env.LS_REPO + '/lsiodev-' + env.CONTAINER_NAME
+          env.GITHUBIMAGE = 'ghcr.io/' + env.LS_USER + '/lsiodev-' + env.CONTAINER_NAME
           env.GITLABIMAGE = 'registry.gitlab.com/linuxserver.io/' + env.LS_REPO + '/lsiodev-' + env.CONTAINER_NAME
           if (env.MULTIARCH == 'true') {
             env.CI_TAGS = 'amd64-' + env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-dev-' + env.COMMIT_SHA + '|arm32v7-' + env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-dev-' + env.COMMIT_SHA + '|arm64v8-' + env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-dev-' + env.COMMIT_SHA
           } else {
             env.CI_TAGS = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-dev-' + env.COMMIT_SHA
           }
+          env.VERSION_TAG = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-dev-' + env.COMMIT_SHA
           env.META_TAG = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-dev-' + env.COMMIT_SHA
           env.EXT_RELEASE_TAG = 'version-' + env.EXT_RELEASE_CLEAN
           env.DOCKERHUB_LINK = 'https://hub.docker.com/r/' + env.DEV_DOCKERHUB_IMAGE + '/tags/'
@@ -162,13 +164,14 @@ pipeline {
       steps {
         script{
           env.IMAGE = env.PR_DOCKERHUB_IMAGE
-          env.GITHUBIMAGE = 'docker.pkg.github.com/' + env.LS_USER + '/' + env.LS_REPO + '/lspipepr-' + env.CONTAINER_NAME
+          env.GITHUBIMAGE = 'ghcr.io/' + env.LS_USER + '/lspipepr-' + env.CONTAINER_NAME
           env.GITLABIMAGE = 'registry.gitlab.com/linuxserver.io/' + env.LS_REPO + '/lspipepr-' + env.CONTAINER_NAME
           if (env.MULTIARCH == 'true') {
             env.CI_TAGS = 'amd64-' + env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-pr-' + env.PULL_REQUEST + '|arm32v7-' + env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-pr-' + env.PULL_REQUEST + '|arm64v8-' + env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-pr-' + env.PULL_REQUEST
           } else {
             env.CI_TAGS = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-pr-' + env.PULL_REQUEST
           }
+          env.VERSION_TAG = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-pr-' + env.PULL_REQUEST
           env.META_TAG = env.EXT_RELEASE_CLEAN + '-pkg-' + env.PACKAGE_TAG + '-pr-' + env.PULL_REQUEST
           env.EXT_RELEASE_TAG = 'version-' + env.EXT_RELEASE_CLEAN
           env.CODE_URL = 'https://github.com/' + env.LS_USER + '/' + env.LS_REPO + '/pull/' + env.PULL_REQUEST
@@ -183,24 +186,24 @@ pipeline {
       }
       steps {
         withCredentials([
-          string(credentialsId: 'spaces-key', variable: 'DO_KEY'),
-          string(credentialsId: 'spaces-secret', variable: 'DO_SECRET')
+          string(credentialsId: 'ci-tests-s3-key-id', variable: 'S3_KEY'),
+          string(credentialsId: 'ci-tests-s3-secret-access-key', variable: 'S3_SECRET')
         ]) {
           script{
-            env.SHELLCHECK_URL = 'https://lsio-ci.ams3.digitaloceanspaces.com/' + env.IMAGE + '/' + env.META_TAG + '/shellcheck-result.xml'
+            env.SHELLCHECK_URL = 'https://ci-tests.linuxserver.io/' + env.IMAGE + '/' + env.META_TAG + '/shellcheck-result.xml'
           }
           sh '''curl -sL https://raw.githubusercontent.com/linuxserver/docker-shellcheck/master/checkrun.sh | /bin/bash'''
           sh '''#! /bin/bash
                 set -e
-                docker pull lsiodev/spaces-file-upload:latest
+                docker pull ghcr.io/linuxserver/lsiodev-spaces-file-upload:latest
                 docker run --rm \
                 -e DESTINATION=\"${IMAGE}/${META_TAG}/shellcheck-result.xml\" \
                 -e FILE_NAME="shellcheck-result.xml" \
                 -e MIMETYPE="text/xml" \
                 -v ${WORKSPACE}:/mnt \
-                -e SECRET_KEY=\"${DO_SECRET}\" \
-                -e ACCESS_KEY=\"${DO_KEY}\" \
-                -t lsiodev/spaces-file-upload:latest \
+                -e SECRET_KEY=\"${S3_SECRET}\" \
+                -e ACCESS_KEY=\"${S3_KEY}\" \
+                -t ghcr.io/linuxserver/lsiodev-spaces-file-upload:latest \
                 python /upload.py'''
         }
       }
@@ -218,8 +221,8 @@ pipeline {
         sh '''#! /bin/bash
               set -e
               TEMPDIR=$(mktemp -d)
-              docker pull linuxserver/jenkins-builder:latest
-              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/jenkins linuxserver/jenkins-builder:latest 
+              docker pull ghcr.io/linuxserver/jenkins-builder:latest
+              docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH=master -v ${TEMPDIR}:/ansible/jenkins ghcr.io/linuxserver/jenkins-builder:latest 
               CURRENTHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
               cd ${TEMPDIR}/docker-${CONTAINER_NAME}
               NEWHASH=$(grep -hs ^ ${TEMPLATED_FILES} | md5sum | cut -c1-8)
@@ -230,9 +233,12 @@ pipeline {
                 git checkout -f master
                 cd ${TEMPDIR}/docker-${CONTAINER_NAME}
                 mkdir -p ${TEMPDIR}/repo/${LS_REPO}/.github/workflows
-                cp --parents ${TEMPLATED_FILES} ${TEMPDIR}/repo/${LS_REPO}/
+                mkdir -p ${TEMPDIR}/repo/${LS_REPO}/.github/ISSUE_TEMPLATE
+                rm -f ${TEMPDIR}/repo/${LS_REPO}/.github/ISSUE_TEMPLATE.md
+                cp --parents ${TEMPLATED_FILES} ${TEMPDIR}/repo/${LS_REPO}/ || :
                 cd ${TEMPDIR}/repo/${LS_REPO}/
                 git add ${TEMPLATED_FILES}
+                git rm .github/ISSUE_TEMPLATE.md || :
                 git commit -m 'Bot Updating Templated Files'
                 git push https://LinuxServer-CI:${GITHUB_TOKEN}@github.com/${LS_USER}/${LS_REPO}.git --all
                 echo "true" > /tmp/${COMMIT_SHA}-${BUILD_NUMBER}
@@ -241,7 +247,7 @@ pipeline {
               fi
               mkdir -p ${TEMPDIR}/gitbook
               git clone https://github.com/linuxserver/docker-documentation.git ${TEMPDIR}/gitbook/docker-documentation
-              if [[ "${BRANCH_NAME}" == "master" ]] && [[ (! -f ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md) || ("$(md5sum ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')") ]]; then
+              if [[ ("${BRANCH_NAME}" == "master") || ("${BRANCH_NAME}" == "main") ]] && [[ (! -f ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md) || ("$(md5sum ${TEMPDIR}/gitbook/docker-documentation/images/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')" != "$(md5sum ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md | awk '{ print $1 }')") ]]; then
                 cp ${TEMPDIR}/docker-${CONTAINER_NAME}/docker-${CONTAINER_NAME}.md ${TEMPDIR}/gitbook/docker-documentation/images/
                 cd ${TEMPDIR}/gitbook/docker-documentation/
                 git add images/docker-${CONTAINER_NAME}.md
@@ -302,8 +308,9 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
+        echo "Running on node: ${NODE_NAME}"
         sh "docker build --no-cache --pull -t ${IMAGE}:${META_TAG} \
-        --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+        --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
       }
     }
     // Build MultiArch Docker containers for push to LS Repo
@@ -315,8 +322,9 @@ pipeline {
       parallel {
         stage('Build X86') {
           steps {
+            echo "Running on node: ${NODE_NAME}"
             sh "docker build --no-cache --pull -t ${IMAGE}:amd64-${META_TAG} \
-            --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+            --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
           }
         }
         stage('Build ARMHF') {
@@ -324,28 +332,20 @@ pipeline {
             label 'ARMHF'
           }
           steps {
-            withCredentials([
-              [
-                $class: 'UsernamePasswordMultiBinding',
-                credentialsId: '3f9ba4d5-100d-45b0-a3c4-633fd6061207',
-                usernameVariable: 'DOCKERUSER',
-                passwordVariable: 'DOCKERPASS'
-              ]
-            ]) {
-              echo 'Logging into DockerHub'
-              sh '''#! /bin/bash
-                 echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
-                 '''
-              sh "docker build --no-cache --pull -f Dockerfile.armhf -t ${IMAGE}:arm32v7-${META_TAG} \
-                           --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
-              sh "docker tag ${IMAGE}:arm32v7-${META_TAG} lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}"
-              retry(5) {
-                sh "docker push lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}"
-              }
-              sh '''docker rmi \
-                    ${IMAGE}:arm32v7-${META_TAG} \
-                    lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} || :'''
+            echo "Running on node: ${NODE_NAME}"
+            echo 'Logging into Github'
+            sh '''#! /bin/bash
+                  echo $GITHUB_TOKEN | docker login ghcr.io -u LinuxServer-CI --password-stdin
+               '''
+            sh "docker build --no-cache --pull -f Dockerfile.armhf -t ${IMAGE}:arm32v7-${META_TAG} \
+                         --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+            sh "docker tag ${IMAGE}:arm32v7-${META_TAG} ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}"
+            retry(5) {
+              sh "docker push ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}"
             }
+            sh '''docker rmi \
+                  ${IMAGE}:arm32v7-${META_TAG} \
+                  ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} || :'''
           }
         }
         stage('Build ARM64') {
@@ -353,28 +353,20 @@ pipeline {
             label 'ARM64'
           }
           steps {
-            withCredentials([
-              [
-                $class: 'UsernamePasswordMultiBinding',
-                credentialsId: '3f9ba4d5-100d-45b0-a3c4-633fd6061207',
-                usernameVariable: 'DOCKERUSER',
-                passwordVariable: 'DOCKERPASS'
-              ]
-            ]) {
-              echo 'Logging into DockerHub'
-              sh '''#! /bin/bash
-                 echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
-                 '''
-              sh "docker build --no-cache --pull -f Dockerfile.aarch64 -t ${IMAGE}:arm64v8-${META_TAG} \
-                           --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${META_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
-              sh "docker tag ${IMAGE}:arm64v8-${META_TAG} lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
-              retry(5) {
-                sh "docker push lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
-              }
-              sh '''docker rmi \
-                    ${IMAGE}:arm64v8-${META_TAG} \
-                    lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} || :'''
+            echo "Running on node: ${NODE_NAME}"
+            echo 'Logging into Github'
+            sh '''#! /bin/bash
+                  echo $GITHUB_TOKEN | docker login ghcr.io -u LinuxServer-CI --password-stdin
+               '''
+            sh "docker build --no-cache --pull -f Dockerfile.aarch64 -t ${IMAGE}:arm64v8-${META_TAG} \
+                         --build-arg ${BUILD_VERSION_ARG}=${EXT_RELEASE} --build-arg VERSION=\"${VERSION_TAG}\" --build-arg BUILD_DATE=${GITHUB_DATE} ."
+            sh "docker tag ${IMAGE}:arm64v8-${META_TAG} ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
+            retry(5) {
+              sh "docker push ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}"
             }
+            sh '''docker rmi \
+                  ${IMAGE}:arm64v8-${META_TAG} \
+                  ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} || :'''
           }
         }
       }
@@ -440,6 +432,13 @@ pipeline {
         environment name: 'EXIT_STATUS', value: ''
       }
       steps {
+        sh '''#! /bin/bash
+              echo "Packages were updated. Cleaning up the image and exiting."
+              if [ "${MULTIARCH}" == "true" ]; then
+                docker rmi ${IMAGE}:amd64-${META_TAG}
+              else
+                docker rmi ${IMAGE}:${META_TAG}
+              fi'''
         script{
           env.EXIT_STATUS = 'ABORTED'
         }
@@ -457,6 +456,13 @@ pipeline {
         }
       }
       steps {
+        sh '''#! /bin/bash
+              echo "There are no package updates. Cleaning up the image and exiting."
+              if [ "${MULTIARCH}" == "true" ]; then
+                docker rmi ${IMAGE}:amd64-${META_TAG}
+              else
+                docker rmi ${IMAGE}:${META_TAG}
+              fi'''
         script{
           env.EXIT_STATUS = 'ABORTED'
         }
@@ -473,20 +479,20 @@ pipeline {
       }
       steps {
         withCredentials([
-          string(credentialsId: 'spaces-key', variable: 'DO_KEY'),
-          string(credentialsId: 'spaces-secret', variable: 'DO_SECRET')
+          string(credentialsId: 'ci-tests-s3-key-id', variable: 'S3_KEY'),
+          string(credentialsId: 'ci-tests-s3-secret-access-key	', variable: 'S3_SECRET')
         ]) {
           script{
-            env.CI_URL = 'https://lsio-ci.ams3.digitaloceanspaces.com/' + env.IMAGE + '/' + env.META_TAG + '/index.html'
+            env.CI_URL = 'https://ci-tests.linuxserver.io/' + env.IMAGE + '/' + env.META_TAG + '/index.html'
           }
           sh '''#! /bin/bash
                 set -e
-                docker pull lsiodev/ci:latest
+                docker pull ghcr.io/linuxserver/lsiodev-ci:latest
                 if [ "${MULTIARCH}" == "true" ]; then
-                  docker pull lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}
-                  docker pull lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}
-                  docker tag lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm32v7-${META_TAG}
-                  docker tag lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm64v8-${META_TAG}
+                  docker pull ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}
+                  docker pull ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}
+                  docker tag ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm32v7-${META_TAG}
+                  docker tag ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm64v8-${META_TAG}
                 fi
                 docker run --rm \
                 --shm-size=1gb \
@@ -498,15 +504,15 @@ pipeline {
                 -e PORT=\"${CI_PORT}\" \
                 -e SSL=\"${CI_SSL}\" \
                 -e BASE=\"${DIST_IMAGE}\" \
-                -e SECRET_KEY=\"${DO_SECRET}\" \
-                -e ACCESS_KEY=\"${DO_KEY}\" \
+                -e SECRET_KEY=\"${S3_SECRET}\" \
+                -e ACCESS_KEY=\"${S3_KEY}\" \
                 -e DOCKER_ENV=\"${CI_DOCKERENV}\" \
                 -e WEB_SCREENSHOT=\"${CI_WEB}\" \
                 -e WEB_AUTH=\"${CI_AUTH}\" \
                 -e WEB_PATH=\"${CI_WEBPATH}\" \
                 -e DO_REGION="ams3" \
                 -e DO_BUCKET="lsio-ci" \
-                -t lsiodev/ci:latest \
+                -t ghcr.io/linuxserver/lsiodev-ci:latest \
                 python /ci/ci.py'''
         }
       }
@@ -533,7 +539,7 @@ pipeline {
             sh '''#! /bin/bash
                   set -e
                   echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
-                  echo $GITHUB_TOKEN | docker login docker.pkg.github.com -u LinuxServer-CI --password-stdin
+                  echo $GITHUB_TOKEN | docker login ghcr.io -u LinuxServer-CI --password-stdin
                   echo $GITLAB_TOKEN | docker login registry.gitlab.com -u LinuxServer.io --password-stdin
                   for PUSHIMAGE in "${GITHUBIMAGE}" "${GITLABIMAGE}" "${IMAGE}"; do
                     docker tag ${IMAGE}:${META_TAG} ${PUSHIMAGE}:${META_TAG}
@@ -546,7 +552,7 @@ pipeline {
                '''
           }
           sh '''#! /bin/bash
-                for DELETEIMAGE in "${GITHUBIMAGE}" "{GITLABIMAGE}" "${IMAGE}"; do
+                for DELETEIMAGE in "${GITHUBIMAGE}" "${GITLABIMAGE}" "${IMAGE}"; do
                   docker rmi \
                   ${DELETEIMAGE}:${META_TAG} \
                   ${DELETEIMAGE}:${EXT_RELEASE_TAG} \
@@ -575,15 +581,15 @@ pipeline {
             sh '''#! /bin/bash
                   set -e
                   echo $DOCKERPASS | docker login -u $DOCKERUSER --password-stdin
-                  echo $GITHUB_TOKEN | docker login docker.pkg.github.com -u LinuxServer-CI --password-stdin
+                  echo $GITHUB_TOKEN | docker login ghcr.io -u LinuxServer-CI --password-stdin
                   echo $GITLAB_TOKEN | docker login registry.gitlab.com -u LinuxServer.io --password-stdin
                   if [ "${CI}" == "false" ]; then
-                    docker pull lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}
-                    docker pull lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}
-                    docker tag lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm32v7-${META_TAG}
-                    docker tag lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm64v8-${META_TAG}
+                    docker pull ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER}
+                    docker pull ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER}
+                    docker tag ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm32v7-${META_TAG}
+                    docker tag ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} ${IMAGE}:arm64v8-${META_TAG}
                   fi
-                  for MANIFESTIMAGE in "${IMAGE}" "${GITLABIMAGE}"; do
+                  for MANIFESTIMAGE in "${IMAGE}" "${GITLABIMAGE}" "${GITHUBIMAGE}"; do
                     docker tag ${IMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:amd64-${META_TAG}
                     docker tag ${IMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG}
                     docker tag ${IMAGE}:arm64v8-${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG}
@@ -610,6 +616,7 @@ pipeline {
                     docker manifest create ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:amd64-${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG}
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm32v7-${META_TAG} --os linux --arch arm
                     docker manifest annotate ${MANIFESTIMAGE}:${META_TAG} ${MANIFESTIMAGE}:arm64v8-${META_TAG} --os linux --arch arm64 --variant v8
+                    docker manifest push --purge ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} || :
                     docker manifest create ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:amd64-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm32v7-${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm64v8-${EXT_RELEASE_TAG}
                     docker manifest annotate ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm32v7-${EXT_RELEASE_TAG} --os linux --arch arm
                     docker manifest annotate ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} ${MANIFESTIMAGE}:arm64v8-${EXT_RELEASE_TAG} --os linux --arch arm64 --variant v8
@@ -617,28 +624,6 @@ pipeline {
                     docker manifest push --purge ${MANIFESTIMAGE}:${META_TAG} 
                     docker manifest push --purge ${MANIFESTIMAGE}:${EXT_RELEASE_TAG} 
                   done
-                  docker tag ${IMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:amd64-${META_TAG}
-                  docker tag ${IMAGE}:arm32v7-${META_TAG} ${GITHUBIMAGE}:arm32v7-${META_TAG}
-                  docker tag ${IMAGE}:arm64v8-${META_TAG} ${GITHUBIMAGE}:arm64v8-${META_TAG}
-                  docker tag ${GITHUBIMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:latest
-                  docker tag ${GITHUBIMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:${META_TAG}
-                  docker tag ${GITHUBIMAGE}:arm32v7-${META_TAG} ${GITHUBIMAGE}:arm32v7-latest
-                  docker tag ${GITHUBIMAGE}:arm64v8-${META_TAG} ${GITHUBIMAGE}:arm64v8-latest
-                  docker tag ${GITHUBIMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:amd64-${EXT_RELEASE_TAG}
-                  docker tag ${GITHUBIMAGE}:amd64-${META_TAG} ${GITHUBIMAGE}:${EXT_RELEASE_TAG}
-                  docker tag ${GITHUBIMAGE}:arm32v7-${META_TAG} ${GITHUBIMAGE}:arm32v7-${EXT_RELEASE_TAG}
-                  docker tag ${GITHUBIMAGE}:arm64v8-${META_TAG} ${GITHUBIMAGE}:arm64v8-${EXT_RELEASE_TAG}
-                  docker push ${GITHUBIMAGE}:amd64-${META_TAG}
-                  docker push ${GITHUBIMAGE}:arm32v7-${META_TAG}
-                  docker push ${GITHUBIMAGE}:arm64v8-${META_TAG}
-                  docker push ${GITHUBIMAGE}:latest
-                  docker push ${GITHUBIMAGE}:${META_TAG}
-                  docker push ${GITHUBIMAGE}:arm32v7-latest
-                  docker push ${GITHUBIMAGE}:arm64v8-latest
-                  docker push ${GITHUBIMAGE}:${EXT_RELEASE_TAG}
-                  docker push ${GITHUBIMAGE}:amd64-${EXT_RELEASE_TAG}
-                  docker push ${GITHUBIMAGE}:arm32v7-${EXT_RELEASE_TAG}
-                  docker push ${GITHUBIMAGE}:arm64v8-${EXT_RELEASE_TAG}
                '''
           }
           sh '''#! /bin/bash
@@ -646,14 +631,17 @@ pipeline {
                   docker rmi \
                   ${DELETEIMAGE}:amd64-${META_TAG} \
                   ${DELETEIMAGE}:amd64-latest \
+                  ${DELETEIMAGE}:amd64-${EXT_RELEASE_TAG} \
                   ${DELETEIMAGE}:arm32v7-${META_TAG} \
                   ${DELETEIMAGE}:arm32v7-latest \
+                  ${DELETEIMAGE}:arm32v7-${EXT_RELEASE_TAG} \
                   ${DELETEIMAGE}:arm64v8-${META_TAG} \
-                  ${DELETEIMAGE}:arm64v8-latest || :
+                  ${DELETEIMAGE}:arm64v8-latest \
+                  ${DELETEIMAGE}:arm64v8-${EXT_RELEASE_TAG} || :
                 done
                 docker rmi \
-                lsiodev/buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} \
-                lsiodev/buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} || :
+                ghcr.io/linuxserver/lsiodev-buildcache:arm32v7-${COMMIT_SHA}-${BUILD_NUMBER} \
+                ghcr.io/linuxserver/lsiodev-buildcache:arm64v8-${COMMIT_SHA}-${BUILD_NUMBER} || :
              '''
         }
       }
@@ -706,9 +694,9 @@ pipeline {
           sh '''#! /bin/bash
                 set -e
                 TEMPDIR=$(mktemp -d)
-                docker pull linuxserver/jenkins-builder:latest
-                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH="${BRANCH_NAME}" -v ${TEMPDIR}:/ansible/jenkins linuxserver/jenkins-builder:latest 
-                docker pull lsiodev/readme-sync
+                docker pull ghcr.io/linuxserver/jenkins-builder:latest
+                docker run --rm -e CONTAINER_NAME=${CONTAINER_NAME} -e GITHUB_BRANCH="${BRANCH_NAME}" -v ${TEMPDIR}:/ansible/jenkins ghcr.io/linuxserver/jenkins-builder:latest 
+                docker pull ghcr.io/linuxserver/lsiodev-readme-sync
                 docker run --rm=true \
                   -e DOCKERHUB_USERNAME=$DOCKERUSER \
                   -e DOCKERHUB_PASSWORD=$DOCKERPASS \
@@ -716,7 +704,7 @@ pipeline {
                   -e DOCKER_REPOSITORY=${IMAGE} \
                   -e GIT_BRANCH=master \
                   -v ${TEMPDIR}/docker-${CONTAINER_NAME}:/mnt \
-                  lsiodev/readme-sync bash -c 'node sync' 
+                  ghcr.io/linuxserver/lsiodev-readme-sync bash -c 'node sync'
                 rm -Rf ${TEMPDIR} '''
         }
       }

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ It is based on alpine and is not meant to run as a service. The sync is performe
 
 |  Date | Changes |
 | :---: | --- |
+| 13.01.21 |  Use ghcr baseimages. Fall back to `external` folder for readme lite. |
 | 28.07.20 |  Rebase to alpine 3.12. |
 | 20.08.18 |  Rebase to alpine 3.8. |
 | 28.02.18 |  convert repo to use node.js implementation. |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -81,6 +81,7 @@ full_custom_readme: |
   
   |  Date | Changes |
   | :---: | --- |
+  | 13.01.21 |  Use ghcr baseimages. Fall back to `external` folder for readme lite. |
   | 28.07.20 |  Rebase to alpine 3.12. |
   | 20.08.18 |  Rebase to alpine 3.8. |
   | 28.02.18 |  convert repo to use node.js implementation. |

--- a/root/opt/docker-readme-sync/package.json
+++ b/root/opt/docker-readme-sync/package.json
@@ -13,11 +13,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/linuxserver/docker-nodejs-readme-sync.git"
+    "url": "git+ssh://git@github.com/linuxserver/docker-readme-sync.git"
   },
   "author": "Paul Hendryx <phendryx@gmail.com>",
   "bugs": {
-    "url": "https://github.com/linuxserver/docker-nodejs-readme-sync/issues"
+    "url": "https://github.com/linuxserver/docker-readme-sync/issues"
   },
-  "homepage": "https://github.com/linuxserver/docker-nodejs-readme-sync#readme"
+  "homepage": "https://github.com/linuxserver/docker-readme-sync"
 }

--- a/root/opt/docker-readme-sync/sync.js
+++ b/root/opt/docker-readme-sync/sync.js
@@ -74,7 +74,10 @@ function run() {
 			try {
 				if (fs.existsSync(readme_lite_file)) {
 				  readme_lite_exists = true
-				}
+				} else if (fs.existsSync('/mnt/external/README.lite')) {
+					readme_lite_file = '/mnt/external/README.lite';
+					readme_lite_exists = true
+				  }
 			} catch(err) {
 				console.log(err)
 			}

--- a/root/opt/docker-readme-sync/sync.js
+++ b/root/opt/docker-readme-sync/sync.js
@@ -68,14 +68,15 @@ function run() {
 		console.log('Getting dockerhub full description for ' + dockerhub_repo);
 		get_dockerhub_readme(dockerhub_repo, function(dockerhub_readme) {
 			
-			// determine if /mnt/README.lite exists
-			var readme_lite_file = '/mnt/README.lite'
+			// determine if README.lite exists
+			var readme_lite_file = 'README.lite'
 			var readme_lite_exists = false
 			try {
-				if (fs.existsSync(readme_lite_file)) {
+				if (fs.existsSync('/mnt/README.lite')) {
+				  readme_lite_file = '/mnt/README.lite';
 				  readme_lite_exists = true
-				} else if (fs.existsSync('/mnt/external/README.lite')) {
-					readme_lite_file = '/mnt/external/README.lite';
+				} else if (fs.existsSync('/mnt/.jenkins-external/README.lite')) {
+					readme_lite_file = '/mnt/.jenkins-external/README.lite';
 					readme_lite_exists = true
 				  }
 			} catch(err) {

--- a/root/opt/docker-readme-sync/sync.js
+++ b/root/opt/docker-readme-sync/sync.js
@@ -1,113 +1,136 @@
-var https = require('https');
+var https = require("https");
 
+var get_github_readme = function (repo, branch, callback) {
+  var repo_parts = repo.split("/");
 
-var get_github_readme = function(repo, branch, callback) {
-	var repo_parts = repo.split('/');
-
-	var readme = "";
-	var url = 'https://raw.githubusercontent.com/' + repo_parts[0] + '/' + repo_parts[1] + '/' + branch + '/README.md'
-	var request = https.get(url, function(response) {
-	    response.on('data', function(chunk) {
-	        readme += chunk;
-	    });
-	    response.on('end', function() {
-	    	callback(readme);
-	    });
-	});
+  var readme = "";
+  var url =
+    "https://raw.githubusercontent.com/" +
+    repo_parts[0] +
+    "/" +
+    repo_parts[1] +
+    "/" +
+    branch +
+    "/README.md";
+  var request = https.get(url, function (response) {
+    response.on("data", function (chunk) {
+      readme += chunk;
+    });
+    response.on("end", function () {
+      callback(readme);
+    });
+  });
 };
-
 
 var get_dockerhub_readme = function (repo, callback) {
-	const dockerHubAPI = require('docker-hub-api');
+  const dockerHubAPI = require("docker-hub-api");
 
-	var repo_parts = repo.split('/');
+  var repo_parts = repo.split("/");
 
-	var repo = dockerHubAPI.repository(repo_parts[0], repo_parts[1]).then(function(info) {
-		var desc = info['full_description']
-		if (desc == null) {
-			desc = ''
-		}
+  var repo = dockerHubAPI
+    .repository(repo_parts[0], repo_parts[1])
+    .then(function (info) {
+      var desc = info["full_description"];
+      if (desc == null) {
+        desc = "";
+      }
 
-		callback(desc);
-	});
+      callback(desc);
+    });
 };
 
-var update_dockerhub_readme = function(user, pass, repo, full_desc, callback) {
-	const dockerHubAPI = require('docker-hub-api');
+var update_dockerhub_readme = function (user, pass, repo, full_desc, callback) {
+  const dockerHubAPI = require("docker-hub-api");
 
-	
-	var repo_parts = repo.split('/');
+  var repo_parts = repo.split("/");
 
-	dockerHubAPI.login(user, pass).then(function(info) {
-		var descriptions = {
-		    full: full_desc
-		};
-		
-		dockerHubAPI.setRepositoryDescription(repo_parts[0], repo_parts[1], descriptions);
+  dockerHubAPI.login(user, pass).then(function (info) {
+    var descriptions = {
+      full: full_desc,
+    };
 
-		callback();
-	});
+    dockerHubAPI.setRepositoryDescription(
+      repo_parts[0],
+      repo_parts[1],
+      descriptions
+    );
+
+    callback();
+  });
 };
 
 function run() {
-	const fs = require('fs')
+  const fs = require("fs");
 
-	var dockerhub_username = process.env.DOCKERHUB_USERNAME
-	var dockerhub_password = process.env.DOCKERHUB_PASSWORD
+  var dockerhub_username = process.env.DOCKERHUB_USERNAME;
+  var dockerhub_password = process.env.DOCKERHUB_PASSWORD;
 
-	var github_repo = process.env.GIT_REPOSITORY;
-	var dockerhub_repo = process.env.DOCKER_REPOSITORY;
+  var github_repo = process.env.GIT_REPOSITORY;
+  var dockerhub_repo = process.env.DOCKER_REPOSITORY;
 
-	var branch = typeof process.env.GIT_BRANCH !== 'undefined' ?  process.env.GIT_BRANCH  : 'master';
+  var branch =
+    typeof process.env.GIT_BRANCH !== "undefined"
+      ? process.env.GIT_BRANCH
+      : "master";
 
-	// Get github readme
-	console.log('Getting github readme for ' + github_repo);
-	get_github_readme(github_repo, branch, function(github_readme) {
+  // Get github readme
+  console.log("Getting github readme for " + github_repo);
+  get_github_readme(github_repo, branch, function (github_readme) {
+    // Get dockerhub full description
+    console.log("Getting dockerhub full description for " + dockerhub_repo);
+    get_dockerhub_readme(dockerhub_repo, function (dockerhub_readme) {
+      // determine if README.lite exists
+      var readme_lite_file = "README.lite";
+      var readme_lite_exists = false;
+      try {
+        if (fs.existsSync("/mnt/README.lite")) {
+          readme_lite_file = "/mnt/README.lite";
+          readme_lite_exists = true;
+        } else if (fs.existsSync("/mnt/.jenkins-external/README.lite")) {
+          readme_lite_file = "/mnt/.jenkins-external/README.lite";
+          readme_lite_exists = true;
+        }
+      } catch (err) {
+        console.log(err);
+      }
+      console.log(`File ${readme_lite_file} exists?: ${readme_lite_exists}.`);
 
-		// Get dockerhub full description
-		console.log('Getting dockerhub full description for ' + dockerhub_repo);
-		get_dockerhub_readme(dockerhub_repo, function(dockerhub_readme) {
-			
-			// determine if README.lite exists
-			var readme_lite_file = 'README.lite'
-			var readme_lite_exists = false
-			try {
-				if (fs.existsSync('/mnt/README.lite')) {
-				  readme_lite_file = '/mnt/README.lite';
-				  readme_lite_exists = true
-				} else if (fs.existsSync('/mnt/.jenkins-external/README.lite')) {
-					readme_lite_file = '/mnt/.jenkins-external/README.lite';
-					readme_lite_exists = true
-				  }
-			} catch(err) {
-				console.log(err)
-			}
-			console.log(`File ${readme_lite_file} exists?: ${readme_lite_exists}.`)
+      // if README.lite exists and github readme is too large, then use README.lite contents
+      if (readme_lite_exists == true && github_readme.length > 25000) {
+        console.log(
+          `Github readme length is larger than 25000, README.lite found, using README.lite`
+        );
+        github_readme = fs.readFileSync(readme_lite_file).toString();
+      }
 
-			// if README.lite exists and github readme is too large, then use README.lite contents
-			if (readme_lite_exists == true && github_readme.length > 25000) {
-				console.log(`Github readme length is larger than 25000, README.lite found, using README.lite`)
-				github_readme = fs.readFileSync(readme_lite_file).toString()
-			}
+      console.log(`Github readme length: ${github_readme.length}.`);
+      console.log(`Dockerhub readme length: ${dockerhub_readme.length}.`);
 
-			console.log(`Github readme length: ${github_readme.length}.`)
-			console.log(`Dockerhub readme length: ${dockerhub_readme.length}.`)
+      if (readme_lite_exists == false && github_readme.length > 25000) {
+        throw new Error(
+          `Github readme is longer than 25,000 characters (length ${github_readme.length}).`
+        );
+      }
 
-			if (readme_lite_exists == false && github_readme.length > 25000) {
-				throw new Error(`Github readme is longer than 25,000 characters (length ${github_readme.length}).`)
-			}
-
-			// If they dont match, update it, else, just notify console it's doing nothing.
-			if (github_readme != dockerhub_readme) {
-				console.log('Github readme and dockerhub full description do not match, updating...')
-				update_dockerhub_readme(dockerhub_username, dockerhub_password, dockerhub_repo, github_readme, function() {
-					console.log('Dockerhub updated.');					
-				});
-			} else {
-				console.log('Github readme and dockerhub full description match.')
-			};
-		});
-	});
-};
+      // If they dont match, update it, else, just notify console it's doing nothing.
+      if (github_readme != dockerhub_readme) {
+        console.log(
+          "Github readme and dockerhub full description do not match, updating..."
+        );
+        update_dockerhub_readme(
+          dockerhub_username,
+          dockerhub_password,
+          dockerhub_repo,
+          github_readme,
+          function () {
+            console.log("Dockerhub updated.");
+          }
+        );
+      } else {
+        console.log("Github readme and dockerhub full description match.");
+      }
+    });
+  });
+}
 
 run();


### PR DESCRIPTION
In the next monthly jenkins builder PR, we are trying to move all external templates (readme lite, documentation, unraid template) into an `.jenkins-external` folder.
This PR adds support for readme lite being in either root or the external folder to smoothen the transition.

PS. the third commit is just formatting changes